### PR TITLE
refactor: remove global font-size from the html tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "url": "https://github.com/edx/frontend-app-library-authoring/issues"
   },
   "dependencies": {
-    "@edx/brand": "npm:@edx/brand-edx.org@^2.0.6",
+    "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
     "@edx/frontend-component-footer": "10.2.1",
     "@edx/frontend-platform": "1.15.2",
     "@edx/paragon": "^19.25.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "url": "https://github.com/edx/frontend-app-library-authoring/issues"
   },
   "dependencies": {
-    "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
+    "@edx/brand": "npm:@edx/brand-edx.org@^2.0.6",
     "@edx/frontend-component-footer": "10.2.1",
     "@edx/frontend-platform": "1.15.2",
     "@edx/paragon": "^19.25.3",

--- a/src/library-authoring/author-library/LibraryAuthoringPage.jsx
+++ b/src/library-authoring/author-library/LibraryAuthoringPage.jsx
@@ -8,11 +8,12 @@ import {
   IconButton,
   Card,
   Navbar,
-  Modal,
+  AlertModal,
   Dropdown,
   SearchField,
   Input,
   Pagination,
+  ActionRow,
 } from '@edx/paragon';
 import { Edit } from '@edx/paragon/icons';
 import { v4 as uuid4 } from 'uuid';
@@ -87,14 +88,14 @@ export const BlockPreviewBase = ({
       <Navbar.Collapse className="justify-content-end">
         { library.allow_lti && (
           <>
-            <Button disabled={isLtiUrlGenerating} size="lg" className="mr-1" onClick={() => { props.fetchBlockLtiUrl({ blockId: block.id }); }}>
+            <Button disabled={isLtiUrlGenerating} size="sm" className="mr-1" onClick={() => { props.fetchBlockLtiUrl({ blockId: block.id }); }}>
               <FontAwesomeIcon icon={faClipboard} className="pr-1" />
               {intl.formatMessage(messages['library.detail.block.copy_lti_url'])}
             </Button>
           </>
         )}
         <Link to={editView}>
-          <Button size="lg" className="mr-1">
+          <Button size="sm" className="mr-1">
             <FontAwesomeIcon icon={faEdit} className="pr-1" />
             {intl.formatMessage(messages['library.detail.block.edit'])}
           </Button>
@@ -102,32 +103,33 @@ export const BlockPreviewBase = ({
         { /* Studio has a copy button, but we don't yet. */}
         <Button
           aria-label={intl.formatMessage(messages['library.detail.block.delete'])}
-          size="lg"
+          size="sm"
           onClick={() => setShowDeleteModal(true)}
         >
           <FontAwesomeIcon icon={faTrashAlt} />
         </Button>
       </Navbar.Collapse>
     </Navbar>
-    <Modal
-      open={showDeleteModal}
+    <AlertModal
+      isOpen={showDeleteModal}
       title={intl.formatMessage(messages['library.detail.block.delete.modal.title'])}
-      onClose={() => setShowDeleteModal(false)}
-      body={(
-        <div>
-          <p>
-            {intl.formatMessage(messages['library.detail.block.delete.modal.body'])}
-          </p>
-        </div>
+      footerNode={(
+        <ActionRow>
+          <Button variant="tertiary" size="md" onClick={() => setShowDeleteModal(false)}>
+            {intl.formatMessage(commonMessages['library.common.forms.button.cancel'])}
+          </Button>
+          <Button
+            variant="primary"
+            size="md"
+            onClick={() => props.deleteLibraryBlock({ blockId: block.id })}
+          >
+            {intl.formatMessage(commonMessages['library.common.forms.button.yes'])}
+          </Button>
+        </ActionRow>
       )}
-      buttons={[
-        <Button
-          onClick={() => props.deleteLibraryBlock({ blockId: block.id })}
-        >
-          {intl.formatMessage(commonMessages['library.common.forms.button.yes'])}
-        </Button>,
-      ]}
-    />
+    >
+      {intl.formatMessage(messages['library.detail.block.delete.modal.body'])}
+    </AlertModal>
     {showPreviews && (
       <Card>
         <Card.Body>
@@ -274,11 +276,11 @@ const ButtonTogglesBase = ({
   library, setShowPreviews, showPreviews, sending, quickAddBehavior, intl,
 }) => (
   <>
-    <Button variant="success" className="mr-1" size="lg" disabled={sending} onClick={quickAddBehavior}>
+    <Button variant="success" className="mr-1" size="sm" disabled={sending} onClick={quickAddBehavior}>
       <FontAwesomeIcon icon={faPlus} className="pr-1" />
       {intl.formatMessage(messages[`library.detail.add_${library.type}`])}
     </Button>
-    <Button variant="primary" className="ml-1" onClick={() => setShowPreviews(!showPreviews)} size="lg">
+    <Button variant="primary" className="ml-1" onClick={() => setShowPreviews(!showPreviews)} size="sm">
       <FontAwesomeIcon icon={faSync} className="pr-1" />
       { intl.formatMessage(showPreviews ? messages['library.detail.hide_previews'] : messages['library.detail.show_previews']) }
     </Button>
@@ -351,7 +353,7 @@ const LibraryAuthoringPageHeaderBase = ({intl, library, ...props}) => {
   return (
     <>
       <small className="card-subtitle">{intl.formatMessage(messages['library.detail.page.heading'])}</small>
-      <h1 className="page-header-title">
+      <h2 className="page-header-title">
         {inputIsActive
           ? (
             <Input
@@ -378,7 +380,7 @@ const LibraryAuthoringPageHeaderBase = ({intl, library, ...props}) => {
             </>
           )
         }
-      </h1>
+      </h2>
     </>
   );
 };
@@ -506,15 +508,15 @@ export const LibraryAuthoringPageBase = ({
                 {library.type === LIBRARY_TYPES.COMPLEX && (
                   <Row>
                     <Col xs={12}>
-                      <h2>{intl.formatMessage(messages['library.detail.add_component_heading'])}</h2>
+                      <h3 className="h3">{intl.formatMessage(messages['library.detail.add_component_heading'])}</h3>
                     </Col>
                     <Col xs={12} className="text-center">
                       <div className="d-inline-block">
                         <Dropdown>
-                          <Dropdown.Toggle variant="success" size="lg" disabled={sending} className="cta-button mr-2" id="library-detail-add-component-dropdown">
+                          <Dropdown.Toggle variant="success" size="sm" disabled={sending} className="cta-button mr-2" id="library-detail-add-component-dropdown">
                             Advanced
                           </Dropdown.Toggle>
-                          <Dropdown.Menu size="lg">
+                          <Dropdown.Menu size="sm">
                             {otherTypes.map((blockSpec) => (
                               <Dropdown.Item
                                 onClick={() => addBlock(blockSpec.block_type)}
@@ -526,13 +528,13 @@ export const LibraryAuthoringPageBase = ({
                           </Dropdown.Menu>
                         </Dropdown>
                       </div>
-                      <Button variant="success" size="lg" disabled={sending} onClick={() => addBlock('html')} className="cta-button">
+                      <Button variant="success" size="sm" disabled={sending} onClick={() => addBlock('html')} className="cta-button">
                         HTML
                       </Button>
-                      <Button variant="success" size="lg" disabled={sending} onClick={() => addBlock('problem')} className="cta-button mx-2">
+                      <Button variant="success" size="sm" disabled={sending} onClick={() => addBlock('problem')} className="cta-button mx-2">
                         Problem
                       </Button>
-                      <Button variant="success" size="lg" disabled={sending} onClick={() => addBlock('video')} className="cta-button">
+                      <Button variant="success" size="sm" disabled={sending} onClick={() => addBlock('video')} className="cta-button">
                         Video
                       </Button>
                     </Col>
@@ -563,7 +565,7 @@ export const LibraryAuthoringPageBase = ({
                       </h3>
                     </Col>
                     <Col xs={12} className="text-center py-3">
-                      <Button size="lg" block disabled={!hasChanges} onClick={commitChanges}>
+                      <Button size="sm" block disabled={!hasChanges} onClick={commitChanges}>
                         {intl.formatMessage(messages['library.detail.aside.publish'])}
                       </Button>
                     </Col>

--- a/src/library-authoring/author-library/index.scss
+++ b/src/library-authoring/author-library/index.scss
@@ -18,25 +18,11 @@
 }
 
 .cta-button {
-  padding: 1rem 2rem;
-  font-size: 120%;
+  padding: 0.625rem 1.25rem;
+  font-size: 1.2rem;
 }
 
 .library-blocks-pagination {
   display: block;
-  margin-top: 1.5em;
-
-  * {
-    font-size: 1.4rem;
-  }
-
-  .pagination {
-    .page-item {
-      .btn {
-        min-width: 2.5em;
-        min-height: 2.5em;
-        border: 1px solid $gray-l2;
-      }
-    }
-  }
+  margin-top: 1rem;
 }

--- a/src/library-authoring/common/LicenseField.jsx
+++ b/src/library-authoring/common/LicenseField.jsx
@@ -38,12 +38,12 @@ export const LicenceFieldBase = (
     </label>
     <Row className="flex-row">
       <Col>
-        <Button name={name} className="text-uppercase mx-1" variant={reservedVariant} size="lg" onClick={() => updateValue('')}>
+        <Button name={name} className="text-uppercase" variant={reservedVariant} size="sm" onClick={() => updateValue('')}>
           {intl.formatMessage(messages['library.common.license.none'])}
         </Button>
       </Col>
       <Col>
-        <Button name={name} className="text-uppercase mx-1" variant={commonsVariant} size="lg" onClick={() => updateValue(spec)}>
+        <Button name={name} className="text-uppercase" variant={commonsVariant} size="sm" onClick={() => updateValue(spec)}>
           {intl.formatMessage(messages['library.common.license.cc'])}
         </Button>
         <p className="small">

--- a/src/library-authoring/common/index.scss
+++ b/src/library-authoring/common/index.scss
@@ -38,17 +38,7 @@
   padding: ($baseline/2);
 }
 
-.page-header-section {
-  h1 {
-    font-family:  "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
-  }
-}
-
 .sidebar-info {
-  font-size: 90%;
-  line-height: 2rem;
-  h3 {
-    font-size: 100%;
-    font-weight: bold;
-  }
+  font-size: 0.9rem;
+  line-height: 1.25rem;
 }

--- a/src/library-authoring/common/messages.js
+++ b/src/library-authoring/common/messages.js
@@ -44,7 +44,7 @@ const messages = defineMessages({
   },
   'library.common.forms.button.yes': {
     id: 'library.common.forms.button.yes',
-    defaultMessage: 'Yes.',
+    defaultMessage: 'Yes',
     description: 'Default label for "Yes" on a confirmation prompt.',
   },
   'library.server.error.generic': {

--- a/src/library-authoring/configure-library/LibraryConfigurePage.jsx
+++ b/src/library-authoring/configure-library/LibraryConfigurePage.jsx
@@ -34,6 +34,7 @@ import {
 import messages from './messages';
 import { LicenseFieldContainer } from '../common/LicenseField';
 
+
 class LibraryConfigurePage extends React.Component {
   constructor(props) {
     super(props);
@@ -182,7 +183,7 @@ class LibraryConfigurePage extends React.Component {
           <header className="mast has-actions has-navigation has-subtitle">
             <div className="page-header">
               <small className="subtitle">{intl.formatMessage(messages['library.edit.page.heading'])}</small>
-              <h1 className="page-header-title">{library.title}</h1>
+              <h2 className="page-header-title">{library.title}</h2>
             </div>
           </header>
         </div>

--- a/src/library-authoring/course-import/CourseImportListItem.jsx
+++ b/src/library-authoring/course-import/CourseImportListItem.jsx
@@ -40,7 +40,8 @@ const CourseImportListItem = ({
       error: <FontAwesomeIcon icon={faSync} className="icon-inline" />,
     },
     disabledStates: ['pending', 'complete'],
-    className: 'btn-lg',
+    // className: 'btn-lg',
+    size: 'sm',
     onClick: handleImport,
   };
 

--- a/src/library-authoring/course-import/CourseImportListItem.jsx
+++ b/src/library-authoring/course-import/CourseImportListItem.jsx
@@ -40,7 +40,6 @@ const CourseImportListItem = ({
       error: <FontAwesomeIcon icon={faSync} className="icon-inline" />,
     },
     disabledStates: ['pending', 'complete'],
-    // className: 'btn-lg',
     size: 'sm',
     onClick: handleImport,
   };

--- a/src/library-authoring/course-import/CourseImportPage.jsx
+++ b/src/library-authoring/course-import/CourseImportPage.jsx
@@ -41,12 +41,12 @@ export const CourseImportPageHeader = ({ intl, showCourses, ...props }) => {
       <header className="mast has-actions has-navigation has-subtitle">
         <div className="page-header">
           <small className="subtitle">{intl.formatMessage(messages['library.course_import.page.parent_heading'])}</small>
-          <h1 className="page-header-title">{intl.formatMessage(messages['library.course_import.page.heading'])}</h1>
+          <h2 className="page-header-title">{intl.formatMessage(messages['library.course_import.page.heading'])}</h2>
         </div>
         <nav className="nav-actions">
           <ul>
             <li className="nav-item">
-              <Button className="toggle-importable-courses" variant="primary" onClick={showCoursesHandler}>
+              <Button className="toggle-importable-courses" variant="primary" size="sm" onClick={showCoursesHandler}>
                 <FontAwesomeIcon icon={faSync} className="pr-3" />
                 {showCourses
                   ? intl.formatMessage(messages['library.course_import.importable_courses.hide'])

--- a/src/library-authoring/create-library/index.scss
+++ b/src/library-authoring/create-library/index.scss
@@ -1,39 +1,233 @@
-.pgn__alert-modal {
-    max-width: 450px;
+.form-create-alert {
+    margin-top: ($baseline*1.6);
+}
 
-    .pgn__modal-title {
-        @include font-size(22);
-        @include line-height(28);
+.dropdown-container {
+    @include pgn-box-shadow(1, 'centered');
 
-        font-weight: 700;
+    border-radius: ($baseline*0.2);
+    max-height: 200px;
+    font-size: 1rem;
+    font-weight: normal;
+    line-height: 1.25rem;
+    overflow-y: scroll;
+    position: absolute;
+    background-color: $white;
+    width: 100%;
+    z-index: 100 !important;
+
+    .dropdown-item {
+        font-size: 1rem;
+        line-height: 1.25rem;
+        padding: ($baseline*0.5) ($baseline*0.8);
+    }
+}
+
+.dropdown-group-wrapper {
+    position: relative;
+}
+
+$baseline: 20px;
+
+.form-create {
+    @include clearfix();
+
+    border-radius: ($baseline*0.3);
+    box-shadow: 0 1px 1px $shadow-l2;
+    margin-bottom: $baseline;
+    border: 1px solid $gray-l2;
+    background: $white;
+    width: 100%;
+    margin-top: ($baseline*1.65);
+
+    .content-primary & {
+        margin-top: 0;
     }
 
-    .pgn__modal-header {
-        padding: 2.5rem 2.5rem 0;
+    fieldset {
+        padding: ($baseline*2.15) ($baseline*2) ($baseline*0.8);
     }
 
-    .pgn__modal-body {
-        padding: 0.8rem 2.5rem;
+    .list-input {
+        @extend %cont-no-list;
+
+        .field {
+            margin: 0 0 ($baseline*1.9) 0;
+
+            &:last-child {
+                margin-bottom: 0;
+            }
+
+            label,
+            input,
+            textarea {
+                display: block;
+            }
+
+            label {
+                font-size: 1rem;
+                line-height: 1.25rem;
+                margin: 0 0 ($baseline/4) 0;
+            }
+
+            input,
+            textarea,
+            select {
+                @extend %t-copy-base;
+
+                @include transition(all $tmg-f2 ease-in-out 0s);
+
+                &.long {
+                    width: 100%;
+                }
+
+                &.short {
+                    width: 25%;
+                }
+
+                &:focus {
+                    + .text-muted {
+                        color: $gray-d1;
+                    }
+                }
+            }
+
+            textarea.long {
+                height: ($baseline*5);
+            }
+
+            input[type="checkbox"] {
+                display: inline-block;
+                margin-right: ($baseline/4);
+                width: auto;
+                height: auto;
+
+                & + label {
+                    display: inline-block;
+                }
+            }
+
+            .text-muted,
+            .invalid-feedback {
+                @extend %t-copy-sub2;
+
+                @include transition(color 0.15s ease-in-out);
+
+
+                display: block;
+                margin-top: ($baseline/4);
+                color: $gray-d1;
+            }
+
+            .tip-note {
+                display: block;
+                margin-top: ($baseline/4);
+            }
+
+            .tip-error {
+                display: none;
+                float: none;
+            }
+
+            .invalid-feedback {
+                color: $red;
+
+                &::before {
+                    vertical-align: unset;
+                }
+            }
+
+            &.error {
+                label {
+                    color: $red;
+                }
+
+                .is-showing {
+                    @extend %anim-fadeIn;
+                }
+
+                .is-hiding {
+                    @extend %anim-fadeOut;
+                }
+
+                .tip-error {
+                    display: block;
+                    color: $red;
+                }
+
+                input {
+                    border-color: $red;
+                }
+            }
+        }
+
+        .library-create-wrapper & .form-control {
+            padding: ($baseline*0.5) ($baseline*0.75);
+            height: ($baseline*2.2);
+        }
+
+        .field-inline {
+            input,
+            textarea,
+            select {
+                width: 62%;
+                display: inline-block;
+            }
+
+            .tip-stacked {
+                display: inline-block;
+                float: right;
+                width: 35%;
+                margin-top: 0;
+            }
+        }
+
+        .field-group {
+            @include clearfix();
+
+            margin: 0 0 ($baseline/2) 0;
+
+            .field {
+                display: block;
+                width: 47%;
+                border-bottom: none;
+                margin: 0 ($baseline*0.75) 0 0;
+                padding: ($baseline/4) 0 0 0;
+                float: left;
+                position: relative;
+
+                &:nth-child(odd) {
+                    float: left;
+                }
+
+                &:nth-child(even) {
+                    float: right;
+                    margin-right: 0;
+                }
+
+                input,
+                textarea {
+                    width: 100%;
+                }
+            }
+        }
     }
 
-    .pgn__modal-body-content {
-        @include font-size(18);
-        @include line-height(28);
+    .pgn__form-control-description {
+        font-size: 0.75rem;
+        line-height: 1.25rem;
 
-        font-weight: 400;
+        .pgn__icon {
+            display: none;
+        }
     }
 
-    .pgn__modal-footer {
-        padding: 6px 2rem 2.5rem;
-    }
+    .actions {
+        padding: ($baseline*0.5) ($baseline*2) ($baseline*0.7);
+        text-align: right;
 
-    .btn {
-        @include font-size(18);
-        @include line-height(24);
-
-        font-weight: 500;
-        padding: 1rem 1.5rem;
-        min-width: 92px;
-        margin-right: 0.3rem;
+        .action {
+            margin-left: 0.5rem;
+        }
     }
 }

--- a/src/library-authoring/create-library/index.scss
+++ b/src/library-authoring/create-library/index.scss
@@ -27,8 +27,6 @@
     position: relative;
 }
 
-$baseline: 20px;
-
 .form-create {
     @include clearfix();
 

--- a/src/library-authoring/edit-block/LibraryBlockPage.jsx
+++ b/src/library-authoring/edit-block/LibraryBlockPage.jsx
@@ -210,12 +210,12 @@ class LibraryBlockPage extends React.Component {
         <div className="wrapper-mast wrapper">
           <header className="mast has-actions has-navigation has-subtitle">
             <div className="page-header">
-              <Button href={ROUTES.Detail.HOME_SLUG(libraryId)} className="my-1">
+              <Button href={ROUTES.Detail.HOME_SLUG(libraryId)} className="my-1" size="sm">
                 <FontAwesomeIcon icon={faArrowLeft} className="pr-1" />
                 {intl.formatMessage(messages['library.block.page.back_to_library'])}
               </Button>
               <small className="subtitle">{intl.formatMessage(messages['library.block.page.heading'])}</small>
-              <h1 className="page-header-title">{metadata !== null && metadata.display_name}</h1>
+              <h2 className="page-header-title">{metadata !== null && metadata.display_name}</h2>
             </div>
           </header>
         </div>
@@ -322,15 +322,16 @@ class LibraryBlockPage extends React.Component {
               </div>
               <div id="publish-unit" className="window">
                 <div className={`bit-publishing ${hasChanges && 'has-warnings'}`}>
-                  <h3 className="bar-mod-title pub-status">
+                  <h4 className="bar-mod-title pub-status h4">
                     {intl.formatMessage(messages[`library.block.aside.${hasChanges ? 'draft' : 'published'}`])}
-                  </h3>
+                  </h4>
                   <div className="wrapper-pub-actions bar-mod-actions">
                     <ul className="action-list list-unstyled">
                       <li className="action-item">
                         <Button
+                          size="sm"
                           variant="primary"
-                          className="w-100 p-2 btn-lg"
+                          className="w-100 p-2"
                           onClick={this.handleCommitLibrary}
                           disabled={!hasChanges}
                           aria-disabled={!hasChanges}
@@ -340,6 +341,7 @@ class LibraryBlockPage extends React.Component {
                       </li>
                       <li className="action-item text-right">
                         <Button
+                          size="sm"
                           variant="link"
                           className="d-inline-block"
                           onClick={this.handleRevertLibrary}
@@ -351,8 +353,9 @@ class LibraryBlockPage extends React.Component {
                       </li>
                       <li className="action-item">
                         <Button
+                          size="sm"
                           variant="danger"
-                          className="w-100 p-2 btn-lg"
+                          className="w-100 p-2"
                           onClick={this.handleDeleteBlock}
                         >
                           <strong>{intl.formatMessage(messages['library.block.aside.delete'])}</strong>

--- a/src/library-authoring/edit-block/index.scss
+++ b/src/library-authoring/edit-block/index.scss
@@ -1,4 +1,12 @@
 .library-block-wrapper {
   margin: 0;
   font-size: 1.4rem;
+
+  .nav-tabs {
+    border-bottom-color: transparent;
+  }
+
+  .card-header {
+    padding-bottom: 0;
+  }
 }

--- a/src/library-authoring/empty-page/EmptyPage.jsx
+++ b/src/library-authoring/empty-page/EmptyPage.jsx
@@ -9,7 +9,7 @@ const EmptyPage = ({
   <div className="empty-sheet-wrapper">
     <div className="empty-content">
       <h3 className="h3">{heading}</h3>
-      <h4 className="h4">{body}</h4>
+      <p>{body}</p>
       {children}
     </div>
   </div>

--- a/src/library-authoring/empty-page/index.scss
+++ b/src/library-authoring/empty-page/index.scss
@@ -1,58 +1,31 @@
-.empty {
-  &-sheet-wrapper {
-    margin: 0;
-    padding: 0;
-    position: relative;
-    background: $light-200;
+.empty-sheet-wrapper {
+  background: $light-200;
+}
+
+.empty-content {
+  margin: 0 auto;
+  text-align: center;
+  padding: 3.25rem 2.5rem;
+  width: flex-grid(9);
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+
+  .h3 {
+    margin-bottom: 1rem;
   }
 
-  &-content {
-    @include clearfix();
+  .pgn__action-row {
+    margin-top: 1.5rem;
+    justify-content: center;
 
-    margin: 0 auto;
-    display: flex;
-    align-items: center;
-    text-align: center;
-    flex-direction: column;
-    border-radius: ($baseline/3.3);
-    padding: ($baseline*2) 0;
-    width: flex-grid(9);
+    .btn {
+      box-shadow: $level-1-box-shadow;
+      padding: 1.125rem 1.25rem;
+      color: $primary-500;
 
-    .pgn__action-row {
-      gap: ($baseline*0.8);
-
-      .btn {
-        @extend %t-demi-strong;
-
-        @include font-size(22);
-        @include line-height(36);
-        box-shadow: $level-1-box-shadow;
-        padding: ($baseline*0.8);
-        color: $primary-500;
-        border-radius: ($baseline*0.2);
-
-        .pgn__icon {
-          width: ($baseline*1.25);
-          height: ($baseline*1.25);
-          right: ($baseline*0.25);
-        }
+      .pgn__icon {
+        margin-right: 0.625rem;
       }
     }
-  }
-
-  &-heading-text {
-    @extend %t-title3;
-    @extend %t-bold;
-
-    @include margin(($baseline*0.25), 0, ($baseline*0.75), 0);
-    color: $primary-500;
-  }
-
-  &-body-text {
-    @extend %t-title4;
-    @extend %t-regular;
-
-    margin-bottom: ($baseline*1.25);
-    color: $gray-700;
   }
 }

--- a/src/library-authoring/library-access/LibraryAccessForm.jsx
+++ b/src/library-authoring/library-access/LibraryAccessForm.jsx
@@ -67,7 +67,7 @@ const LibraryAccessForm = (
             <StatefulButton
               variant="primary"
               type="submit"
-              size="lg"
+              size="sm"
               state={submitButtonState}
               labels={{
                 disabled: intl.formatMessage(commonMessages['library.common.forms.button.submit']),
@@ -80,7 +80,7 @@ const LibraryAccessForm = (
               disabledStates={['disabled', 'pending']}
               className="font-weight-bold text-uppercase"
             />
-            <Button size="lg" variant="secondary" className="mx-3 font-weight-bold text-uppercase" onClick={() => setShowAdd(false)}>
+            <Button size="sm" variant="secondary" className="mx-3 font-weight-bold text-uppercase" onClick={() => setShowAdd(false)}>
               {intl.formatMessage(commonMessages['library.common.forms.button.cancel'])}
             </Button>
           </Card.Section>

--- a/src/library-authoring/library-access/LibraryAccessPage.jsx
+++ b/src/library-authoring/library-access/LibraryAccessPage.jsx
@@ -43,13 +43,14 @@ const LibraryAccessPage = ({
       <header className="mast has-actions has-navigation has-subtitle">
         <div className="page-header">
           <small className="subtitle">{intl.formatMessage(messages['library.access.page.parent_heading'])}</small>
-          <h1 className="page-header-title">{intl.formatMessage(messages['library.access.page.heading'])}</h1>
+          <h2 className="page-header-title">{intl.formatMessage(messages['library.access.page.heading'])}</h2>
         </div>
         <nav className="nav-actions">
           <ul>
             {isAdmin && (
               <li className="nav-item">
                 <Button
+                  size="sm"
                   variant="success"
                   onClick={() => setShowAdd(true)}
                 >
@@ -105,11 +106,11 @@ const LibraryAccessPage = ({
             <div className="well mt-3">
               <Row className="h-100">
                 <Col xs={12} md={8} className="my-auto">
-                  <h2 className="h2 font-weight-bold">{intl.formatMessage(messages['library.access.well.title'])}</h2>
+                  <h4 className="h4 font-weight-bold">{intl.formatMessage(messages['library.access.well.title'])}</h4>
                   <p>{intl.formatMessage(messages['library.access.well.text'])}</p>
                 </Col>
                 <Col xs={12} md={4} lg={3} className="my-auto offset-lg-1 text-center text-md-right">
-                  <Button variant="success" size="lg" onClick={() => setShowAdd(true)}>
+                  <Button variant="success" size="sm" onClick={() => setShowAdd(true)}>
                     <FontAwesomeIcon icon={faPlus} className="pr-1 icon-inline" />
                     <strong>{intl.formatMessage(messages['library.access.well.button'])}</strong>
                   </Button>

--- a/src/library-authoring/library-access/UserAccessWidget.jsx
+++ b/src/library-authoring/library-access/UserAccessWidget.jsx
@@ -2,8 +2,7 @@
 Component for displaying and modifying a user's access level for a library.
  */
 import {
-  Badge,
-  Button, Card, Col, Modal, Row,
+  ActionRow, AlertModal, Badge, Button, Card, Col, Row,
 } from '@edx/paragon';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
@@ -30,9 +29,9 @@ export const UserAccessWidget = ({
           <strong>{intl.formatMessage(messages[`library.access.info.${user.access_level}`])}</strong>&nbsp;
           <span className="font-weight-normal">{isUser && intl.formatMessage(messages['library.access.info.self'])}</span>
         </Badge>
-        <Row className="py-3">
+        <Row className="py-3 px-3">
           <Col xs={12} md={6}>
-            <span className="title title-2">
+            <span className="title title-2 h4">
               <span className="font-weight-bold">{user.username}</span>
             </span>
             <span className="title px-2">
@@ -49,36 +48,37 @@ export const UserAccessWidget = ({
               )}
               {user.access_level === LIBRARY_ACCESS.ADMIN && multipleAdmins && (
               <Col xs={10} className="text-left text-md-right">
-                <Button size="lg" variant="secondary" onClick={() => setShowDeprivModal(true)}>
+                <Button size="sm" variant="secondary" onClick={() => setShowDeprivModal(true)}>
                   {intl.formatMessage(messages['library.access.remove_admin'])}
                 </Button>
-                <Modal
-                  open={showDeprivModal}
+                <AlertModal
+                  isOpen={showDeprivModal}
                   title={intl.formatMessage(messages['library.access.modal.remove_admin.title'])}
-                  onClose={() => setShowDeprivModal(false)}
-                  body={(
-                    <div>
-                      <p>
-                        {intl.formatMessage(
-                          messages['library.access.modal.remove_admin.body'],
-                          { library: library.title, email: user.email },
-                        )}
-                      </p>
-                    </div>
+                  footerNode={(
+                    <ActionRow>
+                      <Button variant="tertiary" size="md" onClick={() => setShowDeprivModal(false)}>
+                        {intl.formatMessage(commonMessages['library.common.forms.button.cancel'])}
+                      </Button>
+                      <Button
+                        variant="primary"
+                        size="md"
+                        onClick={() => setAccessLevel(LIBRARY_ACCESS.AUTHOR).then(setShowDeprivModal(false))}
+                      >
+                        {intl.formatMessage(commonMessages['library.common.forms.button.yes'])}
+                      </Button>
+                    </ActionRow>
                   )}
-                  buttons={[
-                    <Button
-                      onClick={() => setAccessLevel(LIBRARY_ACCESS.AUTHOR).then(setShowDeprivModal(false))}
-                    >
-                      {intl.formatMessage(commonMessages['library.common.forms.button.yes'])}
-                    </Button>,
-                  ]}
-                />
+                >
+                  {intl.formatMessage(
+                    messages['library.access.modal.remove_admin.body'],
+                    { library: library.title, email: user.email },
+                  )}
+                </AlertModal>
               </Col>
               )}
               {user.access_level === LIBRARY_ACCESS.READ && (
               <Col xs={10} className="text-left text-md-right">
-                <Button size="lg" variant="primary" onClick={() => setAccessLevel(LIBRARY_ACCESS.AUTHOR)}>
+                <Button size="sm" variant="primary" onClick={() => setAccessLevel(LIBRARY_ACCESS.AUTHOR)}>
                   {intl.formatMessage(messages['library.access.add_author'])}
                 </Button>
               </Col>
@@ -86,12 +86,12 @@ export const UserAccessWidget = ({
               {user.access_level === LIBRARY_ACCESS.AUTHOR && (
                 <>
                   <Col xs={5} className="text-left text-md-right pl-md-1">
-                    <Button size="lg" variant="secondary" onClick={() => setAccessLevel(LIBRARY_ACCESS.READ)}>
+                    <Button size="sm" variant="secondary" onClick={() => setAccessLevel(LIBRARY_ACCESS.READ)}>
                       {intl.formatMessage(messages['library.access.remove_author'])}
                     </Button>
                   </Col>
                   <Col xs={5} className="text-left text-md-right pl-md-1">
-                    <Button size="lg" variant="primary" onClick={() => setAccessLevel(LIBRARY_ACCESS.ADMIN)}>
+                    <Button size="sm" variant="primary" onClick={() => setAccessLevel(LIBRARY_ACCESS.ADMIN)}>
                       {intl.formatMessage(messages['library.access.add_admin'])}
                     </Button>
                   </Col>
@@ -100,7 +100,7 @@ export const UserAccessWidget = ({
               {(!((user.access_level === LIBRARY_ACCESS.ADMIN) && adminLocked)) && (
               <Col xs={2} className="text-right text-md-center">
                 <Button
-                  size="lg"
+                  size="sm"
                   variant="danger"
                   onClick={() => setShowRemoveModal(true)}
                   aria-label={
@@ -109,26 +109,25 @@ export const UserAccessWidget = ({
                 >
                   <FontAwesomeIcon icon={faTrash} />
                 </Button>
-                <Modal
-                  open={showRemoveModal}
+                <AlertModal
+                  isOpen={showRemoveModal}
                   title={intl.formatMessage(messages['library.access.modal.remove.title'])}
-                  onClose={() => setShowRemoveModal(false)}
-                  body={(
-                    <div>
-                      <p>
-                        {intl.formatMessage(
-                          messages['library.access.modal.remove.body'],
-                          { library: library.title, email: user.email },
-                        )}
-                      </p>
-                    </div>
-                    )}
-                  buttons={[
-                    <Button onClick={() => removeAccess()}>
-                      {intl.formatMessage(commonMessages['library.common.forms.button.yes'])}
-                    </Button>,
-                  ]}
-                />
+                  footerNode={(
+                    <ActionRow>
+                      <Button variant="tertiary" size="md" onClick={() => setShowRemoveModal(false)}>
+                        {intl.formatMessage(commonMessages['library.common.forms.button.cancel'])}
+                      </Button>
+                      <Button variant="primary" size="md" onClick={() => removeAccess()}>
+                        {intl.formatMessage(commonMessages['library.common.forms.button.yes'])}
+                      </Button>
+                    </ActionRow>
+                  )}
+                >
+                  {intl.formatMessage(
+                    messages['library.access.modal.remove.body'],
+                    { library: library.title, email: user.email },
+                  )}
+                </AlertModal>
               </Col>
               )}
             </Row>

--- a/src/library-authoring/library-access/UserAccessWidget.jsx
+++ b/src/library-authoring/library-access/UserAccessWidget.jsx
@@ -29,7 +29,7 @@ export const UserAccessWidget = ({
           <strong>{intl.formatMessage(messages[`library.access.info.${user.access_level}`])}</strong>&nbsp;
           <span className="font-weight-normal">{isUser && intl.formatMessage(messages['library.access.info.self'])}</span>
         </Badge>
-        <Row className="py-3 px-3">
+        <Row className="p-3">
           <Col xs={12} md={6}>
             <span className="title title-2 h4">
               <span className="font-weight-bold">{user.username}</span>

--- a/src/library-authoring/library-access/index.scss
+++ b/src/library-authoring/library-access/index.scss
@@ -35,9 +35,23 @@
   font-size: 150%;
 }
 
-.library-access-wrapper .form-create {
-  border: none;
-  &:hover {
-    box-shadow: none;
+.library-access-wrapper {
+  .form-create {
+    border: none;
+
+    &:hover {
+      box-shadow: none;
+    }
+
+    fieldset {
+      padding: 0 0.625rem;
+    }
+  }
+
+  .pgn__card-body {
+    .btn {
+      height: 100%;
+    }
   }
 }
+

--- a/src/library-authoring/list-libraries/LibraryListPage.jsx
+++ b/src/library-authoring/list-libraries/LibraryListPage.jsx
@@ -110,15 +110,15 @@ export class LibraryListPage extends React.Component {
 
     return (
       <div className="library-list-wrapper">
+        <Breadcrumb
+          links={[
+            { label: intl.formatMessage(commonMessages['library.common.breadcrumbs.studio']), url: getConfig().STUDIO_BASE_URL },
+          ]}
+          activeLabel={intl.formatMessage(messages['library.list.breadcrumbs.libraries'])}
+        />
         <div className="wrapper-mast wrapper">
-          <Breadcrumb
-            links={[
-              { label: intl.formatMessage(commonMessages['library.common.breadcrumbs.studio']), url: getConfig().STUDIO_BASE_URL },
-            ]}
-            activeLabel={intl.formatMessage(messages['library.list.breadcrumbs.libraries'])}
-          />
           <header className="mast has-actions">
-            <h1 className="page-header">{intl.formatMessage(messages['library.list.page.heading'])}</h1>
+            <h2 className="page-header">{intl.formatMessage(messages['library.list.page.heading'])}</h2>
             <nav className="nav-actions">
               <ul className="nav-list">
                 <li className="nav-item">
@@ -137,7 +137,7 @@ export class LibraryListPage extends React.Component {
         </div>
         <div className="wrapper-content wrapper">
           <section className="content">
-            <article className="content-primary" role="main">
+            <article className="content-fullwidth" role="main">
               {libraries.count > 0
                 ? (
                   <ul className="library-list">

--- a/src/library-authoring/list-libraries/index.scss
+++ b/src/library-authoring/list-libraries/index.scss
@@ -6,29 +6,15 @@
   font-size: 1.4rem;
 
   .library-list-pagination {
-    display: block;
-    margin-top: 1.5em;
-
-    * {
-      font-size: 1.4rem;
-    }
-
-    .pagination {
-      justify-content: center;
-      .page-item {
-        .btn {
-          min-width: 2.5em;
-          min-height: 2.5em;
-        }
-      }
-    }
+    margin-top: 1.5rem;
   }
 
   .library-list {
     border-radius: ($baseline*0.3);
     background: $white;
     padding: 0;
-    margin: 0;
+    margin: -($baseline/2) 0 0;
+    list-style: none;
 
     .library-item.no-hover-bg {
       &:hover {
@@ -37,42 +23,26 @@
     }
 
     .library-item {
-      @extend %ui-depth2;
-      @include margin-right(2%);
-
-      box-sizing: border-box;
-      width: 100%;
-      position: relative;
       border: 1px solid $light-700;
-      border-radius: ($baseline*0.3);
       box-shadow: none;
-      outline: none;
-      padding: ($baseline*1.20);
-      display: inline-block;
-      vertical-align: middle;
-      
+      padding: 1.5rem 1.375rem 1.75rem;
+
       .pgn__card-header {
         padding: 0;
+      }
 
-        &-content {
-          margin-top: 0;
-        }
-        &-title-md {
-          @extend %t-title4;
-          @extend %t-bold;
-          @include margin(0, ($baseline*2), ($baseline/1.25), 0);
-          
-          color: $primary-500;
-        }
+      .pgn__card-header-content {
+        margin-top: 0;
+      }
+
+      .pgn__card-header-title-md {
+        @extend .h4;
+
+        color: $primary-500;
       }
 
       .library-title {
-        @extend %t-title4;
-        @extend %t-bold;
-
-        @include margin(0, ($baseline*2), ($baseline/4), 0);
-        @include font-size(18);
-        @include line-height(24);
+        margin-bottom: 0.875rem;
       }
 
       .library-metadata {
@@ -87,8 +57,8 @@
 
           & + .metadata-item::before {
             content: "•";
-            margin-left: ($baseline/4);
-            margin-right: ($baseline/4);
+            margin-left: 0.5rem;
+            margin-right: 0.5rem;
             color: $gray-500;
           }
 
@@ -122,13 +92,14 @@
   }
 
   .filter-form {
-    .form-label {
+    .pgn__form-label {
+      font-size: 0.75rem;
       font-weight: 600;
     }
 
     button,
     .form-control {
-      font-size: 1.4rem;
+      font-size: 0.75rem;
     }
   }
 }

--- a/src/library-authoring/studio-header/StudioHeader.jsx
+++ b/src/library-authoring/studio-header/StudioHeader.jsx
@@ -42,13 +42,13 @@ const StudioHeader = ({ intl, library }) => {
                     <span className="library-title" title={library.title}>{library.title}</span>
                   </Link>
                 </h2>
-                <nav className="p-4 mt-2">
+                <nav className="p-3 mt-1">
                   <Dropdown>
                     <Dropdown.Toggle variant="outline-light" id="library-header-menu-dropdown">
                       {intl.formatMessage(messages['library.header.settings.menu'])}
                       <Icon className="fa fa-caret-down pl-3" alt="" />
                     </Dropdown.Toggle>
-                    <Dropdown.Menu className="p-4 mt-1 fade">
+                    <Dropdown.Menu className="mt-1 fade">
                       <Dropdown.Item className="p-0" as={Link} to={ROUTES.Detail.EDIT_SLUG(library.id)}>{intl.formatMessage(messages['library.header.settings.details'])}</Dropdown.Item>
                       <Dropdown.Item className="p-0" as={Link} to={ROUTES.Detail.ACCESS_SLUG(library.id)}>{intl.formatMessage(messages['library.header.settings.access'])}</Dropdown.Item>
                       <Dropdown.Item className="p-0" as={Link} to={ROUTES.Detail.IMPORT_SLUG(library.id)}>{intl.formatMessage(messages['library.header.settings.import'])}</Dropdown.Item>
@@ -62,7 +62,7 @@ const StudioHeader = ({ intl, library }) => {
         <div className="wrapper-r">
           {authenticatedUser !== null
           && (
-          <nav className="p-4 mt-2" aria-label={intl.formatMessage(messages['library.header.account.label'])}>
+          <nav className="p-3 mt-1" aria-label={intl.formatMessage(messages['library.header.account.label'])}>
             <ol>
               <li className="nav-item nav-account-help">
                 <h3 className="title">
@@ -82,9 +82,9 @@ const StudioHeader = ({ intl, library }) => {
                     {authenticatedUser.username}
                     <Icon className="fa fa-caret-down pl-3" alt="" />
                   </Dropdown.Toggle>
-                  <Dropdown.Menu className="dropdown-menu-right p-4 mt-1 fade">
-                    <Dropdown.Item className="p-0 mb-3" href={config.STUDIO_BASE_URL}>{intl.formatMessage(messages['library.header.account.studiohome'])}</Dropdown.Item>
-                    <Dropdown.Item className="p-0 mb-3" href={`${config.STUDIO_BASE_URL}/maintenance`}>{intl.formatMessage(messages['library.header.account.maintenance'])}</Dropdown.Item>
+                  <Dropdown.Menu className="dropdown-menu-right mt-1 fade">
+                    <Dropdown.Item className="p-0 mb-1" href={config.STUDIO_BASE_URL}>{intl.formatMessage(messages['library.header.account.studiohome'])}</Dropdown.Item>
+                    <Dropdown.Item className="p-0 mb-1" href={`${config.STUDIO_BASE_URL}/maintenance`}>{intl.formatMessage(messages['library.header.account.maintenance'])}</Dropdown.Item>
                     <Dropdown.Item className="p-0" href={config.LOGOUT_URL}>{intl.formatMessage(messages['library.header.account.signout'])}</Dropdown.Item>
                   </Dropdown.Menu>
                 </Dropdown>

--- a/src/library-authoring/studio-header/index.scss
+++ b/src/library-authoring/studio-header/index.scss
@@ -57,26 +57,39 @@
   nav {
     .dropdown {
       .btn {
-        font-size: 1.6rem;
+        font-size: 1rem;
         font-weight: 600;
         background-color: white;
         color: $gray-d1;
         border-width: 1px;
-        line-height: 2.368rem;
+        line-height: 1.475rem;
+        padding: 0.234rem 0.469rem;
+        border-radius: ($baseline*0.1);
+        border-color: #f8f9fa;
 
         &:hover {
           color: $uxpl-blue-hover-active;
         }
+
+        &:focus:before {
+          border-radius: 2px;
+        }
       }
 
       .dropdown-menu {
-        font-size: 1.4rem;
         width: 160px;
+        min-width: 160px;
+        padding: 0.875rem;
       }
 
-      .dropdown-item:active {
-        color: $uxpl-blue-hover-active;
-        background-color: white;
+      .dropdown-item {
+        font-size: 0.875rem;
+        line-height: 1.48rem;
+
+        &:active {
+          color: $uxpl-blue-hover-active;
+          background-color: white;
+        }
       }
     }
 
@@ -97,9 +110,9 @@
 
         .title {
           max-width: ($baseline*10.5);
-          font-size: 1.6rem;
+          font-size: 1rem;
           font-weight: 600;
-          padding: 0.375rem 1.25rem;
+          padding: 0.234rem 0.781rem;
           margin: 0;
         }
 
@@ -117,7 +130,7 @@
 
   .branding {
     padding: ($baseline*0.75) 0;
-    margin-right: 2.5rem;
+    margin-right: 1.563rem;
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -141,6 +154,7 @@
     .library-org,
     .library-id {
       @extend %t-action4;
+      @extend %t-demi-strong;
 
       display: inline-block;
       vertical-align: middle;
@@ -150,8 +164,8 @@
       text-overflow: ellipsis;
       opacity: 1;
       color: $gray-d3;
-      font-size: 1.2rem;
-      line-height: 1.776rem;
+      font-size: 0.75rem;
+      line-height: 1.1rem;
     }
 
     .library-org {
@@ -167,8 +181,8 @@
       overflow: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;
-      line-height: 2.368rem;
-      font-size: 1.6rem;
+      line-height: 1.48rem;
+      font-size: 1rem;
     }
 
     .library-link {
@@ -177,6 +191,7 @@
       display: block;
       color: $gray-d3;
       text-decoration: none;
+      font-size: 1rem;
 
       &:hover {
         color: $uxpl-blue-hover-active;

--- a/src/library-authoring/studio-header/index.scss
+++ b/src/library-authoring/studio-header/index.scss
@@ -1,3 +1,5 @@
+$header-dopdown-border-color: #f8f9fa;
+
 /* Adapted from:
  * edx-platform/cms/static/sass/elements/_header.scss
  */
@@ -59,13 +61,13 @@
       .btn {
         font-size: 1rem;
         font-weight: 600;
-        background-color: white;
+        background-color: $white;
         color: $gray-d1;
         border-width: 1px;
         line-height: 1.475rem;
         padding: 0.234rem 0.469rem;
         border-radius: ($baseline*0.1);
-        border-color: #f8f9fa;
+        border-color: $header-dopdown-border-color;
 
         &:hover {
           color: $uxpl-blue-hover-active;
@@ -88,7 +90,7 @@
 
         &:active {
           color: $uxpl-blue-hover-active;
-          background-color: white;
+          background-color: $white;
         }
       }
     }

--- a/src/vendor/overrides.scss
+++ b/src/vendor/overrides.scss
@@ -1,4 +1,4 @@
-// Vendor verrides
+// Vendor overrides
 
 // edx-pattern-library
 $pink: #e83e8c !default;
@@ -12,4 +12,39 @@ $font-family-sans-serif: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-s
   max-width: 1376px;
   padding-left: 0;
   padding-right: 0;
+}
+
+// Paragon breadcrumbs
+.pgn__breadcrumb {
+  font-size: 1.125rem;
+  line-height: 1.5rem;
+  margin: ($baseline*2.2) 0;
+
+  .list-inline-item:not(:last-child) {
+    margin-right: 0.3rem;
+  }
+}
+
+// Paragon alert modal
+.pgn__alert-modal {
+  max-width: 450px;
+
+  .pgn__modal-title {
+    font-size: 1.375rem;
+    line-height: 1.75rem;
+  }
+
+  .pgn__modal-body-content {
+    font-size: 1.125rem;
+    line-height: 1.75rem;
+  }
+
+  .btn {
+    min-width: 92px;
+  }
+}
+
+// Paragon pagination
+.pagination {
+  justify-content: center;
 }

--- a/src/vendor/studio.scss
+++ b/src/vendor/studio.scss
@@ -3,9 +3,9 @@
 @font-face {
   font-family: 'Open Sans';
   src:
-    url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-Light-webfont.woff2') format('woff2'),
-    url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-Light-webfont.woff') format('woff'),
-    url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-Light-webfont.ttf') format('truetype');
+      url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-Light-webfont.woff2') format('woff2'),
+      url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-Light-webfont.woff') format('woff'),
+      url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-Light-webfont.ttf') format('truetype');
   font-weight: 300;
   font-style: normal;
 }
@@ -13,9 +13,9 @@
 @font-face {
   font-family: 'Open Sans';
   src:
-    url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-LightItalic-webfont.woff2') format('woff2'),
-    url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-LightItalic-webfont.woff') format('woff'),
-    url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-LightItalic-webfont.ttf') format('truetype');
+      url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-LightItalic-webfont.woff2') format('woff2'),
+      url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-LightItalic-webfont.woff') format('woff'),
+      url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-LightItalic-webfont.ttf') format('truetype');
   font-weight: 300;
   font-style: italic;
 }
@@ -23,9 +23,9 @@
 @font-face {
   font-family: 'Open Sans';
   src:
-    url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-Regular-webfont.woff2') format('woff2'),
-    url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-Regular-webfont.woff') format('woff'),
-    url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-Regular-webfont.ttf') format('truetype');
+      url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-Regular-webfont.woff2') format('woff2'),
+      url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-Regular-webfont.woff') format('woff'),
+      url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-Regular-webfont.ttf') format('truetype');
   font-weight: 400;
   font-style: normal;
 }
@@ -33,9 +33,9 @@
 @font-face {
   font-family: 'Open Sans';
   src:
-    url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-Italic-webfont.woff2') format('woff2'),
-    url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-Italic-webfont.woff') format('woff'),
-    url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-Italic-webfont.ttf') format('truetype');
+      url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-Italic-webfont.woff2') format('woff2'),
+      url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-Italic-webfont.woff') format('woff'),
+      url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-Italic-webfont.ttf') format('truetype');
   font-weight: 400;
   font-style: italic;
 }
@@ -43,9 +43,9 @@
 @font-face {
   font-family: 'Open Sans';
   src:
-    url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-Semibold-webfont.woff2') format('woff2'),
-    url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-Semibold-webfont.woff') format('woff'),
-    url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-Semibold-webfont.ttf') format('truetype');
+      url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-Semibold-webfont.woff2') format('woff2'),
+      url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-Semibold-webfont.woff') format('woff'),
+      url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-Semibold-webfont.ttf') format('truetype');
   font-weight: 600;
   font-style: normal;
 }
@@ -53,9 +53,9 @@
 @font-face {
   font-family: 'Open Sans';
   src:
-    url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-SemiboldItalic-webfont.woff2') format('woff2'),
-    url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-SemiboldItalic-webfont.woff') format('woff'),
-    url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-SemiboldItalic-webfont.ttf') format('truetype');
+      url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-SemiboldItalic-webfont.woff2') format('woff2'),
+      url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-SemiboldItalic-webfont.woff') format('woff'),
+      url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-SemiboldItalic-webfont.ttf') format('truetype');
   font-weight: 600;
   font-style: italic;
 }
@@ -63,9 +63,9 @@
 @font-face {
   font-family: 'Open Sans';
   src:
-    url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-Bold-webfont.woff2') format('woff2'),
-    url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-Bold-webfont.woff') format('woff'),
-    url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-Bold-webfont.ttf') format('truetype');
+      url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-Bold-webfont.woff2') format('woff2'),
+      url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-Bold-webfont.woff') format('woff'),
+      url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-Bold-webfont.ttf') format('truetype');
   font-weight: 700;
   font-style: normal;
 }
@@ -73,9 +73,9 @@
 @font-face {
   font-family: 'Open Sans';
   src:
-    url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-BoldItalic-webfont.woff2') format('woff2'),
-    url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-BoldItalic-webfont.woff') format('woff'),
-    url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-BoldItalic-webfont.ttf') format('truetype');
+      url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-BoldItalic-webfont.woff2') format('woff2'),
+      url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-BoldItalic-webfont.woff') format('woff'),
+      url('~edx-pattern-library/pattern-library/fonts/OpenSans/OpenSans-BoldItalic-webfont.ttf') format('truetype');
   font-weight: 700;
   font-style: italic;
 }
@@ -226,8 +226,8 @@ $prefix-for-spec:      true !default; // required for keyframe mixin
   // If $pos is missing from mixin, reassign vars and add default position
   @if ($pos-type == color) or (nth($pos, 1) == "transparent")  {
     $G10: $G9; $G9: $G8; $G8: $G7; $G7: $G6; $G6: $G5;
-     $G5: $G4; $G4: $G3; $G3: $G2; $G2: $G1; $G1: $pos;
-     $pos: null;
+    $G5: $G4; $G4: $G3; $G3: $G2; $G2: $G1; $G1: $pos;
+    $pos: null;
   }
 
   @if $pos {
@@ -436,12 +436,12 @@ $yellow-u3: desaturate($yellow, 45%) !default;
 
 @mixin line-height($fontSize: 16) {
   line-height: $fontSize + px;
-  line-height: ($fontSize/10) + rem;
+  line-height: ($fontSize/16) + rem;
 }
 
 @mixin font-size($sizeValue: 16) {
   font-size: $sizeValue + px;
-  font-size: ($sizeValue/10) + rem;
+  font-size: ($sizeValue/16) + rem;
 }
 
 %cont-text-sr {
@@ -505,8 +505,8 @@ $yellow-u3: desaturate($yellow, 45%) !default;
 %t-copy-base {
   @extend %t-copy;
 
-  @include font-size(14);
-  @include line-height(24);
+  font-size: 0.875rem;
+  line-height: 1.294rem;
 }
 
 %t-copy-sub1 {
@@ -802,18 +802,6 @@ $yellow-u3: desaturate($yellow, 45%) !default;
   .alert-heading {
     @include font-size(18);
     @include line-height(24);
-  }
-}
-
-.pgn__breadcrumb {
-  @include font-size(18);
-  @include line-height(24);
-
-  margin: ($baseline*2.2) 0 ($baseline*2);
-
-  .pgn__icon {
-    width: 2.4rem;
-    height: 2.4rem;
   }
 }
 
@@ -1128,8 +1116,7 @@ $bi-app-right           : right;
 // Imported from:
 // edx-platform/cms/static/sass/_base.scss
 html {
-  font-size: 62.5%;
-  height: 100%; // force scrollbar to prevent jump when scroll appears, cannot use overflow because it breaks drag
+  height: 100%;
 }
 
 body {
@@ -1153,18 +1140,15 @@ body {
 body,
 input,
 button {
-  font-family: $f-sans-serif;
+  font-family: $font-family-sans-serif;
 }
 
 .page-header {
-  @extend %t-title2;
-  @extend %t-bold;
-
   display: block;
 
   .navigation,
   .subtitle {
-    @extend %t-title7;
+    @extend .h5;
     @extend %t-regular;
 
     position: relative;
@@ -1221,7 +1205,6 @@ button {
         @include margin-right(flex-gutter());
 
         .page-header-title {
-          @extend %t-title4;
           @extend %t-strong;
 
           margin: 12px 0;
@@ -1236,18 +1219,13 @@ button {
         width: flex-grid(6, 12);
 
         @include text-align(right);
-        .nav-list {
-          margin-top: ($baseline/1.5);
-        }
+
         .nav-item {
           display: inline-block;
           vertical-align: top;
           line-height: 1.776rem;
 
           button {
-            font-size: 1.2rem;
-            font-weight: 600;
-
             svg {
               width: 2rem;
             }
@@ -1299,15 +1277,6 @@ main {
       margin: 0;
       color: $gray-l2;
     }
-
-    .title-1 {
-      @extend %t-title3;
-
-      margin: 0;
-      padding: 0;
-      font-weight: 600;
-      color: $gray-d3;
-    }
   }
 }
 
@@ -1317,22 +1286,12 @@ main {
 }
 
 .content-primary {
-  flex: 0 0 100%;
-  width: 100%;
+  flex: 0 0 75%;
+  width: 75%;
   margin-right: 2.12%;
 
-  .title-1 {
-    @extend %t-title3;
-  }
-
-  .title-2 {
-    @extend %t-title4;
-
-    margin: 0 0 ($baseline/2) 0;
-  }
-
   .title-3 {
-    @extend %t-title6;
+    @extend .h6;
 
     margin: 0 0 ($baseline/2) 0;
   }
@@ -1359,6 +1318,11 @@ main {
   }
 }
 
+.content-fullwidth {
+  flex: 0 0 100%;
+  width: 100%;
+}
+
 .content-supplementary {
   flex: 0 0 25%;
   max-width: 25%;
@@ -1378,7 +1342,7 @@ main {
     }
 
     h3 {
-      @extend %t-title7;
+      @extend .h5;
       @extend %t-strong;
 
       margin: 0 0 ($baseline/4) 0;
@@ -1386,7 +1350,7 @@ main {
     }
 
     p {
-      line-height: 20.7167px;
+      line-height: 1.294rem;
     }
 
     .list-actions {
@@ -1475,7 +1439,7 @@ main {
     text-align: center;
 
     h5 {
-      @extend %t-title5;
+      @extend .h5;
       @extend %t-strong;
 
       margin-bottom: ($baseline*0.75);
@@ -1686,7 +1650,6 @@ main {
   background-color: $white;
 
   .bar-mod-title {
-    @extend %t-title6;
     @extend %t-strong;
 
     display: block;
@@ -1701,7 +1664,7 @@ main {
     padding: ($baseline*0.75) ($baseline*0.75) $baseline ($baseline*0.75);
 
     .title {
-      @extend %t-title8;
+      @extend .h6;
       @extend %t-strong;
 
       margin-bottom: ($baseline/4);
@@ -1771,12 +1734,12 @@ main {
 // edx-platform/cms/static/sass/views/_container.scss
 
 %status-value-base {
-  @extend %t-title7;
+  @extend .h5;
   @extend %t-strong;
 }
 
 %status-value-sub1 {
-  @extend %t-title8;
+  @extend .h6;
 
   display: block;
 }
@@ -1901,48 +1864,4 @@ main {
       }
     }
   }
-}
-
-.dropdown-group-wrapper {
-  position: relative;
-
-  .pgn__form-control-decorator-trailing {
-    @include font-size(22);
-
-    .btn-icon.btn-icon-sm {
-      width: 3.6rem;
-      height: 3.6rem;
-    }
-
-    .pgn__icon.btn-icon__icon {
-      height: 2.4rem;
-      width: 2.4rem;
-    }
-  }
-}
-
-.dropdown-container {
-  @include pgn-box-shadow(1, 'centered');
-
-  border-radius: ($baseline*0.2);
-  max-height: 200px;
-  font-size: 1rem;
-  font-weight: normal;
-  line-height: 1.25rem;
-  overflow-y: scroll;
-  position: absolute;
-  background-color: $white;
-  width: 100%;
-  z-index: 100 !important;
-
-  .dropdown-item {
-    @include font-size(16);
-    @include line-height(20);
-
-    padding: ($baseline*0.5) ($baseline*0.8);
-  }
-}
-
-.wrapper .list-inline-item:not(:last-child) {
-  margin-right: 0.3rem;
 }


### PR DESCRIPTION
**Description:**
The main aim is to remove global scale from the `html { font-size: 62.5%; }` tag. Consequently, all of child nodes have 1rem = 10px instead of base 16px. Because of this, everyone has to add more styles to all paragon components every time we use them because they are all based on rem units.
In addition, all pages were fixed and displayed correctly according to the current paragon style.

**Youtrack:** https://youtrack.raccoongang.com/issue/EDX_BLND_CLI-240