### PR TITLE
feat: add empty options list message

### DIFF
--- a/src/library-authoring/common/OrganizationDropdown.jsx
+++ b/src/library-authoring/common/OrganizationDropdown.jsx
@@ -4,12 +4,16 @@ import { Icon, IconButton } from '@edx/paragon';
 import { ExpandLess, ExpandMore } from '@edx/paragon/icons';
 import PropTypes from 'prop-types';
 import onClickOutside from 'react-onclickoutside';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import FormGroup from './FormGroup';
+
+import messages from './messages';
 
 class OrganizationDropdown extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
+      isFocused: false,
       displayValue: '',
       icon: this.expandMoreButton(),
       errorMessage: '',
@@ -132,10 +136,12 @@ class OrganizationDropdown extends React.Component {
   }
 
   handleFocus(e) {
+    this.setState({ isFocused: true });
     if (this.props.handleFocus) { this.props.handleFocus(e); }
   }
 
   handleOnBlur(e) {
+    this.setState({ isFocused: false });
     if (this.props.handleBlur) { this.props.handleBlur(e); }
   }
 
@@ -173,6 +179,12 @@ class OrganizationDropdown extends React.Component {
   }
 
   render() {
+    const noOptionsMessage = (
+      <button className="dropdown-item" type="button" disabled>
+        {this.props.intl.formatMessage(messages['library.organizations.list.empty'])}
+      </button>
+    );
+    const dropDownEmptyList = this.state.dropDownItems && this.state.isFocused ? noOptionsMessage : null;
     return (
       <div className="dropdown-group-wrapper">
         <FormGroup
@@ -192,7 +204,7 @@ class OrganizationDropdown extends React.Component {
           handleFocus={this.handleFocus}
         />
         <div className="dropdown-container">
-          { this.state.dropDownItems.length > 0 ? this.state.dropDownItems : null }
+          { this.state.dropDownItems.length > 0 ? this.state.dropDownItems : dropDownEmptyList }
         </div>
       </div>
     );
@@ -214,6 +226,7 @@ OrganizationDropdown.defaultProps = {
 };
 
 OrganizationDropdown.propTypes = {
+  intl: intlShape.isRequired,
   options: PropTypes.arrayOf(PropTypes.string),
   floatingLabel: PropTypes.string,
   handleFocus: PropTypes.func,
@@ -228,4 +241,4 @@ OrganizationDropdown.propTypes = {
   controlClassName: PropTypes.string,
 };
 
-export default onClickOutside(OrganizationDropdown);
+export default injectIntl(onClickOutside(OrganizationDropdown));

--- a/src/library-authoring/common/messages.js
+++ b/src/library-authoring/common/messages.js
@@ -166,6 +166,11 @@ const messages = defineMessages({
     defaultMessage: 'Studio',
     description: 'Text for link to studio.',
   },
+  'library.organizations.list.empty': {
+    id: 'library.organizations.list.empty',
+    defaultMessage: 'No options',
+    description: 'Text for empty organizations options list.',
+  },
 });
 
 export default messageGuard(messages);

--- a/src/library-authoring/common/specs/OrganizationDropdown.spec.jsx
+++ b/src/library-authoring/common/specs/OrganizationDropdown.spec.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';
-import { IntlProvider, injectIntl } from '@edx/frontend-platform/i18n';
+import { injectIntl } from '@edx/frontend-platform/i18n';
 import OrganizationDropdown from '../OrganizationDropdown';
+import { ctxMount } from './helpers';
 
 const initFireEvent = () => {
   const map = {};
@@ -34,17 +34,13 @@ const InjectedOrganizationDropdown = injectIntl(OrganizationDropdown);
 
 describe('common/OrganizationDropdown.jsx', () => {
   it('renders component without error', () => {
-    mount(<IntlProvider locale="en">
-      <InjectedOrganizationDropdown {...props} />
-    </IntlProvider>);
+    ctxMount(<InjectedOrganizationDropdown {...props} />);
   });
 
   it('handles element focus', () => {
     const mockHandleFocus = jest.fn();
     const newProps = { ...props, handleFocus: mockHandleFocus };
-    const container = mount(<IntlProvider locale="en">
-      <InjectedOrganizationDropdown {...newProps} />
-    </IntlProvider>);
+    const container = ctxMount(<InjectedOrganizationDropdown {...newProps} />);
     container.find('input').simulate('focus');
 
     expect(mockHandleFocus).toHaveBeenCalled();
@@ -53,9 +49,7 @@ describe('common/OrganizationDropdown.jsx', () => {
   it('handles element blur', () => {
     const mockHandleBlur = jest.fn();
     const newProps = { ...props, handleBlur: mockHandleBlur };
-    const container = mount(<IntlProvider locale="en">
-      <InjectedOrganizationDropdown {...newProps} />
-    </IntlProvider>);
+    const container = ctxMount(<InjectedOrganizationDropdown {...newProps} />);
     container.find('input').simulate('blur');
 
     expect(mockHandleBlur).toHaveBeenCalled();
@@ -63,9 +57,7 @@ describe('common/OrganizationDropdown.jsx', () => {
 
   it('renders component with options', () => {
     const newProps = { ...props, options: ['opt1', 'opt2'] };
-    const container = mount(<IntlProvider locale="en">
-      <InjectedOrganizationDropdown {...newProps} />
-    </IntlProvider>);
+    const container = ctxMount(<InjectedOrganizationDropdown {...newProps} />);
 
     container.find('input').simulate('click');
     container.update();
@@ -75,9 +67,7 @@ describe('common/OrganizationDropdown.jsx', () => {
 
   it('selects option', () => {
     const newProps = { ...props, options: ['opt1', 'opt2'] };
-    const container = mount(<IntlProvider locale="en">
-      <InjectedOrganizationDropdown {...newProps} />
-    </IntlProvider>);
+    const container = ctxMount(<InjectedOrganizationDropdown {...newProps} />);
 
     container.find('input').simulate('click');
     container.find('.dropdown-container').find('button').at(0).simulate('click');
@@ -86,9 +76,7 @@ describe('common/OrganizationDropdown.jsx', () => {
 
   it('toggles options list', () => {
     const newProps = { ...props, options: ['opt1', 'opt2'] };
-    const container = mount(<IntlProvider locale="en">
-      <InjectedOrganizationDropdown {...newProps} />
-    </IntlProvider>);
+    const container = ctxMount(<InjectedOrganizationDropdown {...newProps} />);
 
     expect(container.find('.dropdown-container').find('button').length).toEqual(0);
     container.find('button.expand-more').simulate('click');
@@ -99,9 +87,7 @@ describe('common/OrganizationDropdown.jsx', () => {
 
   it('shows options list depends on field value', () => {
     const newProps = { ...props, options: ['opt1', 'opt2'] };
-    const container = mount(<IntlProvider locale="en">
-      <InjectedOrganizationDropdown {...newProps} />
-    </IntlProvider>);
+    const container = ctxMount(<InjectedOrganizationDropdown {...newProps} />);
 
     container.find('input').simulate('change', { target: { value: '1' } });
     expect(container.find('.dropdown-container').find('button').length).toEqual(1);
@@ -110,9 +96,7 @@ describe('common/OrganizationDropdown.jsx', () => {
   it('closes options list on click outside', () => {
     const fireEvent = initFireEvent();
     const newProps = { ...props, options: ['opt1', 'opt2'] };
-    const container = mount(<IntlProvider locale="en">
-      <InjectedOrganizationDropdown {...newProps} />
-    </IntlProvider>);
+    const container = ctxMount(<InjectedOrganizationDropdown {...newProps} />);
 
     container.find('input').simulate('click');
     expect(container.find('.dropdown-container').find('button').length).toEqual(2);
@@ -123,9 +107,7 @@ describe('common/OrganizationDropdown.jsx', () => {
 
   it('shows empty options list depends on field value', () => {
     const newProps = { ...props, options: ['opt1', 'opt2'] };
-    const container = mount(<IntlProvider locale="en">
-      <InjectedOrganizationDropdown {...newProps} />
-    </IntlProvider>);
+    const container = ctxMount(<InjectedOrganizationDropdown {...newProps} />);
 
     container.find('input').simulate('change', { target: { value: '3' } });
     container.find('input').simulate('focus');

--- a/src/library-authoring/common/specs/OrganizationDropdown.spec.jsx
+++ b/src/library-authoring/common/specs/OrganizationDropdown.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';
+import { IntlProvider, injectIntl } from '@edx/frontend-platform/i18n';
 import OrganizationDropdown from '../OrganizationDropdown';
 
 const initFireEvent = () => {
@@ -29,16 +30,21 @@ const props = {
   errorCode: null,
   readOnly: false,
 };
+const InjectedOrganizationDropdown = injectIntl(OrganizationDropdown);
 
 describe('common/OrganizationDropdown.jsx', () => {
   it('renders component without error', () => {
-    mount(<OrganizationDropdown {...props} />);
+    mount(<IntlProvider locale="en">
+      <InjectedOrganizationDropdown {...props} />
+    </IntlProvider>);
   });
 
   it('handles element focus', () => {
     const mockHandleFocus = jest.fn();
     const newProps = { ...props, handleFocus: mockHandleFocus };
-    const container = mount(<OrganizationDropdown {...newProps} />);
+    const container = mount(<IntlProvider locale="en">
+      <InjectedOrganizationDropdown {...newProps} />
+    </IntlProvider>);
     container.find('input').simulate('focus');
 
     expect(mockHandleFocus).toHaveBeenCalled();
@@ -47,7 +53,9 @@ describe('common/OrganizationDropdown.jsx', () => {
   it('handles element blur', () => {
     const mockHandleBlur = jest.fn();
     const newProps = { ...props, handleBlur: mockHandleBlur };
-    const container = mount(<OrganizationDropdown {...newProps} />);
+    const container = mount(<IntlProvider locale="en">
+      <InjectedOrganizationDropdown {...newProps} />
+    </IntlProvider>);
     container.find('input').simulate('blur');
 
     expect(mockHandleBlur).toHaveBeenCalled();
@@ -55,7 +63,9 @@ describe('common/OrganizationDropdown.jsx', () => {
 
   it('renders component with options', () => {
     const newProps = { ...props, options: ['opt1', 'opt2'] };
-    const container = mount(<OrganizationDropdown {...newProps} />);
+    const container = mount(<IntlProvider locale="en">
+      <InjectedOrganizationDropdown {...newProps} />
+    </IntlProvider>);
 
     container.find('input').simulate('click');
     container.update();
@@ -65,7 +75,9 @@ describe('common/OrganizationDropdown.jsx', () => {
 
   it('selects option', () => {
     const newProps = { ...props, options: ['opt1', 'opt2'] };
-    const container = mount(<OrganizationDropdown {...newProps} />);
+    const container = mount(<IntlProvider locale="en">
+      <InjectedOrganizationDropdown {...newProps} />
+    </IntlProvider>);
 
     container.find('input').simulate('click');
     container.find('.dropdown-container').find('button').at(0).simulate('click');
@@ -74,7 +86,9 @@ describe('common/OrganizationDropdown.jsx', () => {
 
   it('toggles options list', () => {
     const newProps = { ...props, options: ['opt1', 'opt2'] };
-    const container = mount(<OrganizationDropdown {...newProps} />);
+    const container = mount(<IntlProvider locale="en">
+      <InjectedOrganizationDropdown {...newProps} />
+    </IntlProvider>);
 
     expect(container.find('.dropdown-container').find('button').length).toEqual(0);
     container.find('button.expand-more').simulate('click');
@@ -85,7 +99,9 @@ describe('common/OrganizationDropdown.jsx', () => {
 
   it('shows options list depends on field value', () => {
     const newProps = { ...props, options: ['opt1', 'opt2'] };
-    const container = mount(<OrganizationDropdown {...newProps} />);
+    const container = mount(<IntlProvider locale="en">
+      <InjectedOrganizationDropdown {...newProps} />
+    </IntlProvider>);
 
     container.find('input').simulate('change', { target: { value: '1' } });
     expect(container.find('.dropdown-container').find('button').length).toEqual(1);
@@ -94,12 +110,26 @@ describe('common/OrganizationDropdown.jsx', () => {
   it('closes options list on click outside', () => {
     const fireEvent = initFireEvent();
     const newProps = { ...props, options: ['opt1', 'opt2'] };
-    const container = mount(<OrganizationDropdown {...newProps} />);
+    const container = mount(<IntlProvider locale="en">
+      <InjectedOrganizationDropdown {...newProps} />
+    </IntlProvider>);
 
     container.find('input').simulate('click');
     expect(container.find('.dropdown-container').find('button').length).toEqual(2);
     act(() => { fireEvent.mousedown({ target: document.body }); });
     container.update();
     expect(container.find('.dropdown-container').find('button').length).toEqual(0);
+  });
+
+  it('shows empty options list depends on field value', () => {
+    const newProps = { ...props, options: ['opt1', 'opt2'] };
+    const container = mount(<IntlProvider locale="en">
+      <InjectedOrganizationDropdown {...newProps} />
+    </IntlProvider>);
+
+    container.find('input').simulate('change', { target: { value: '3' } });
+    container.find('input').simulate('focus');
+    expect(container.find('.dropdown-container').find('button').length).toEqual(1);
+    expect(container.find('.dropdown-container').find('button').at(0).text()).toEqual('No options');
   });
 });

--- a/src/library-authoring/configure-library/LibraryConfigurePage.jsx
+++ b/src/library-authoring/configure-library/LibraryConfigurePage.jsx
@@ -34,7 +34,6 @@ import {
 import messages from './messages';
 import { LicenseFieldContainer } from '../common/LicenseField';
 
-
 class LibraryConfigurePage extends React.Component {
   constructor(props) {
     super(props);

--- a/src/library-authoring/create-library/LibraryCreatePage.jsx
+++ b/src/library-authoring/create-library/LibraryCreatePage.jsx
@@ -191,20 +191,22 @@ export class LibraryCreatePage extends React.Component {
     const { intl, errorMessage, orgs } = this.props;
     const { data, isOpenModal, allowLeave } = this.state;
     const { config } = this.context;
-    const error = errorMessage || this.props.errorFields
+    const errorTitle = !errorMessage && this.props.errorFields
+      && intl.formatMessage(messages['library.form.generic.error.title']);
+    const errorDescription = errorMessage || this.props.errorFields
       ? intl.formatMessage(messages['library.form.generic.error.description']) : '';
 
     return (
       <div className="container-fluid">
         <div className="library-create-wrapper">
-          {error && (
+          {errorDescription && (
             <Alert
               icon={Info}
               variant="danger"
               className="form-create-alert"
             >
-              <Alert.Heading>{intl.formatMessage(messages['library.form.generic.error.title'])}</Alert.Heading>
-              <p>{truncateMessage(error)}</p>
+              {errorTitle && <Alert.Heading>{errorTitle}</Alert.Heading>}
+              <p>{truncateMessage(errorDescription)}</p>
             </Alert>
           )}
           <Breadcrumb
@@ -244,6 +246,7 @@ export class LibraryCreatePage extends React.Component {
                         disabled
                         type="text"
                         name="org"
+                        intl={intl}
                         readOnly={false}
                         value={data.org}
                         options={orgs}


### PR DESCRIPTION
**Description:**
- Implement empty options message for organizations drop-down on the create library page.
- Extend the error message to show global errors.

**Youtrack:**
https://youtrack.raccoongang.com/issue/EDX_BLND_CLI-277